### PR TITLE
fix: enable touch scaling on chart

### DIFF
--- a/src/components/charts/KLineProChart.tsx
+++ b/src/components/charts/KLineProChart.tsx
@@ -167,6 +167,11 @@ export default function KLineProChart({
         theme === "dark" ? "#0a0a0a" : "#ffffff"
       }; width: 100%; height: 100%; box-sizing: border-box; }
       #app { width: 100%; height: ${height}px; overflow: hidden; }
+
+      /* Ensure all chart elements can handle custom touch gestures */
+      .klinecharts-pro, .klinecharts-pro * {
+        touch-action: none;
+      }
       
       /* KLine Pro CSS variable overrides */
       .klinecharts-pro {
@@ -734,7 +739,7 @@ export default function KLineProChart({
         domStorageEnabled
         startInLoadingState={false}
         scalesPageToFit={false}
-        scrollEnabled={false}
+        scrollEnabled
         onMessage={(e) => {
           try {
             const msg = JSON.parse(e.nativeEvent.data);


### PR DESCRIPTION
## Summary
- allow touch gestures on KLine charts by disabling default touch-action
- enable WebView scrolling so price-axis dragging zooms chart

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b684978e2483318c5dc0dea0aee561